### PR TITLE
support skipping of assistents

### DIFF
--- a/TESetupAssistant/SetupAssistantMini.xib
+++ b/TESetupAssistant/SetupAssistantMini.xib
@@ -2,25 +2,25 @@
 <archive type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="8.00">
 	<data>
 		<int key="IBDocument.SystemTarget">1070</int>
-		<string key="IBDocument.SystemVersion">11B26</string>
-		<string key="IBDocument.InterfaceBuilderVersion">1934</string>
-		<string key="IBDocument.AppKitVersion">1138</string>
-		<string key="IBDocument.HIToolboxVersion">566.00</string>
+		<string key="IBDocument.SystemVersion">11G63</string>
+		<string key="IBDocument.InterfaceBuilderVersion">3084</string>
+		<string key="IBDocument.AppKitVersion">1138.51</string>
+		<string key="IBDocument.HIToolboxVersion">569.00</string>
 		<object class="NSMutableDictionary" key="IBDocument.PluginVersions">
 			<string key="NS.key.0">com.apple.InterfaceBuilder.CocoaPlugin</string>
-			<string key="NS.object.0">1934</string>
+			<string key="NS.object.0">3084</string>
 		</object>
 		<array key="IBDocument.IntegratedClassDependencies">
+			<string>IBNSLayoutConstraint</string>
+			<string>NSBox</string>
+			<string>NSButton</string>
+			<string>NSButtonCell</string>
+			<string>NSCustomObject</string>
+			<string>NSCustomView</string>
 			<string>NSTextField</string>
+			<string>NSTextFieldCell</string>
 			<string>NSView</string>
 			<string>NSWindowTemplate</string>
-			<string>NSBox</string>
-			<string>NSTextFieldCell</string>
-			<string>NSCustomView</string>
-			<string>NSButtonCell</string>
-			<string>IBNSLayoutConstraint</string>
-			<string>NSButton</string>
-			<string>NSCustomObject</string>
 		</array>
 		<array key="IBDocument.PluginDependencies">
 			<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
@@ -62,11 +62,13 @@
 									<string key="NSFrame">{{1, 1}, {459, 231}}</string>
 									<reference key="NSSuperview" ref="146005933"/>
 									<reference key="NSWindow"/>
+									<reference key="NSNextKeyView" ref="627233489"/>
 								</object>
 							</array>
 							<string key="NSFrame">{{20, 56}, {461, 233}}</string>
 							<reference key="NSSuperview" ref="942749259"/>
 							<reference key="NSWindow"/>
+							<reference key="NSNextKeyView" ref="306321701"/>
 							<string key="NSOffsets">{0, 0}</string>
 							<object class="NSTextFieldCell" key="NSTitleCell">
 								<int key="NSCellFlags">67239424</int>
@@ -111,6 +113,7 @@
 							<string key="NSFrame">{{17, 297}, {467, 18}}</string>
 							<reference key="NSSuperview" ref="942749259"/>
 							<reference key="NSWindow"/>
+							<reference key="NSNextKeyView" ref="146005933"/>
 							<bool key="NSEnabled">YES</bool>
 							<object class="NSTextFieldCell" key="NSCell" id="979690127">
 								<int key="NSCellFlags">68288064</int>
@@ -148,6 +151,7 @@
 							<string key="NSFrame">{{380, 12}, {107, 32}}</string>
 							<reference key="NSSuperview" ref="942749259"/>
 							<reference key="NSWindow"/>
+							<reference key="NSNextKeyView"/>
 							<bool key="NSEnabled">YES</bool>
 							<object class="NSButtonCell" key="NSCell" id="249210746">
 								<int key="NSCellFlags">67239424</int>
@@ -173,6 +177,7 @@
 							<string key="NSFrame">{{273, 12}, {107, 32}}</string>
 							<reference key="NSSuperview" ref="942749259"/>
 							<reference key="NSWindow"/>
+							<reference key="NSNextKeyView" ref="874635734"/>
 							<bool key="NSEnabled">YES</bool>
 							<object class="NSButtonCell" key="NSCell" id="996589196">
 								<int key="NSCellFlags">67239424</int>
@@ -191,17 +196,19 @@
 						<object class="NSCustomView" id="627233489">
 							<reference key="NSNextResponder" ref="942749259"/>
 							<int key="NSvFlags">290</int>
-							<string key="NSFrame">{{20, 8}, {251, 43}}</string>
+							<string key="NSFrame">{{20, 0}, {251, 51}}</string>
 							<reference key="NSSuperview" ref="942749259"/>
 							<reference key="NSWindow"/>
+							<reference key="NSNextKeyView" ref="75290957"/>
 							<string key="NSClassName">NSView</string>
 						</object>
 					</array>
 					<string key="NSFrameSize">{501, 326}</string>
 					<reference key="NSSuperview"/>
 					<reference key="NSWindow"/>
+					<reference key="NSNextKeyView" ref="354401613"/>
 				</object>
-				<string key="NSScreenRect">{{0, 0}, {1680, 1028}}</string>
+				<string key="NSScreenRect">{{0, 0}, {1280, 778}}</string>
 				<string key="NSMaxSize">{10000000000000, 10000000000000}</string>
 				<bool key="NSWindowIsRestorable">YES</bool>
 			</object>
@@ -332,117 +339,21 @@
 							<reference ref="354401613"/>
 							<reference ref="874635734"/>
 							<reference ref="146005933"/>
-							<object class="IBNSLayoutConstraint" id="359000243">
-								<reference key="firstItem" ref="146005933"/>
+							<object class="IBNSLayoutConstraint" id="585003142">
+								<reference key="firstItem" ref="874635734"/>
 								<int key="firstAttribute">5</int>
 								<int key="relation">0</int>
-								<reference key="secondItem" ref="942749259"/>
-								<int key="secondAttribute">5</int>
-								<float key="multiplier">1</float>
-								<object class="IBNSLayoutSymbolicConstant" key="constant">
-									<double key="value">20</double>
-								</object>
-								<float key="priority">1000</float>
-								<int key="scoringType">8</int>
-								<float key="scoringTypeFloat">29</float>
-								<int key="contentType">3</int>
-								<reference key="containingView" ref="942749259"/>
-							</object>
-							<object class="IBNSLayoutConstraint" id="606436537">
-								<reference key="firstItem" ref="942749259"/>
-								<int key="firstAttribute">6</int>
-								<int key="relation">0</int>
-								<reference key="secondItem" ref="146005933"/>
+								<reference key="secondItem" ref="75290957"/>
 								<int key="secondAttribute">6</int>
 								<float key="multiplier">1</float>
 								<object class="IBNSLayoutSymbolicConstant" key="constant">
-									<double key="value">20</double>
+									<double key="value">12</double>
 								</object>
 								<float key="priority">1000</float>
-								<int key="scoringType">8</int>
-								<float key="scoringTypeFloat">29</float>
-								<int key="contentType">3</int>
 								<reference key="containingView" ref="942749259"/>
-							</object>
-							<object class="IBNSLayoutConstraint" id="626044727">
-								<reference key="firstItem" ref="75290957"/>
-								<int key="firstAttribute">5</int>
-								<int key="relation">0</int>
-								<reference key="secondItem" ref="627233489"/>
-								<int key="secondAttribute">6</int>
-								<float key="multiplier">1</float>
-								<object class="IBNSLayoutSymbolicConstant" key="constant">
-									<double key="value">8</double>
-								</object>
-								<float key="priority">1000</float>
 								<int key="scoringType">6</int>
 								<float key="scoringTypeFloat">24</float>
 								<int key="contentType">3</int>
-								<reference key="containingView" ref="942749259"/>
-							</object>
-							<object class="IBNSLayoutConstraint" id="208632930">
-								<reference key="firstItem" ref="942749259"/>
-								<int key="firstAttribute">6</int>
-								<int key="relation">0</int>
-								<reference key="secondItem" ref="874635734"/>
-								<int key="secondAttribute">6</int>
-								<float key="multiplier">1</float>
-								<object class="IBNSLayoutSymbolicConstant" key="constant">
-									<double key="value">20</double>
-								</object>
-								<float key="priority">1000</float>
-								<int key="scoringType">8</int>
-								<float key="scoringTypeFloat">29</float>
-								<int key="contentType">3</int>
-								<reference key="containingView" ref="942749259"/>
-							</object>
-							<object class="IBNSLayoutConstraint" id="387158952">
-								<reference key="firstItem" ref="627233489"/>
-								<int key="firstAttribute">5</int>
-								<int key="relation">0</int>
-								<reference key="secondItem" ref="942749259"/>
-								<int key="secondAttribute">5</int>
-								<float key="multiplier">1</float>
-								<object class="IBNSLayoutSymbolicConstant" key="constant">
-									<double key="value">20</double>
-								</object>
-								<float key="priority">1000</float>
-								<int key="scoringType">8</int>
-								<float key="scoringTypeFloat">29</float>
-								<int key="contentType">3</int>
-								<reference key="containingView" ref="942749259"/>
-							</object>
-							<object class="IBNSLayoutConstraint" id="339948509">
-								<reference key="firstItem" ref="942749259"/>
-								<int key="firstAttribute">4</int>
-								<int key="relation">0</int>
-								<reference key="secondItem" ref="75290957"/>
-								<int key="secondAttribute">4</int>
-								<float key="multiplier">1</float>
-								<object class="IBNSLayoutSymbolicConstant" key="constant">
-									<double key="value">20</double>
-								</object>
-								<float key="priority">1000</float>
-								<int key="scoringType">8</int>
-								<float key="scoringTypeFloat">29</float>
-								<int key="contentType">3</int>
-								<reference key="containingView" ref="942749259"/>
-							</object>
-							<object class="IBNSLayoutConstraint" id="1042134971">
-								<reference key="firstItem" ref="942749259"/>
-								<int key="firstAttribute">6</int>
-								<int key="relation">0</int>
-								<reference key="secondItem" ref="354401613"/>
-								<int key="secondAttribute">6</int>
-								<float key="multiplier">1</float>
-								<object class="IBNSLayoutSymbolicConstant" key="constant">
-									<double key="value">20</double>
-								</object>
-								<float key="priority">1000</float>
-								<int key="scoringType">8</int>
-								<float key="scoringTypeFloat">29</float>
-								<int key="contentType">3</int>
-								<reference key="containingView" ref="942749259"/>
 							</object>
 							<object class="IBNSLayoutConstraint" id="124283355">
 								<reference key="firstItem" ref="942749259"/>
@@ -455,106 +366,26 @@
 									<double key="value">20</double>
 								</object>
 								<float key="priority">1000</float>
+								<reference key="containingView" ref="942749259"/>
 								<int key="scoringType">8</int>
 								<float key="scoringTypeFloat">29</float>
 								<int key="contentType">3</int>
-								<reference key="containingView" ref="942749259"/>
 							</object>
-							<object class="IBNSLayoutConstraint" id="408792166">
-								<reference key="firstItem" ref="146005933"/>
-								<int key="firstAttribute">3</int>
+							<object class="IBNSLayoutConstraint" id="208632930">
+								<reference key="firstItem" ref="942749259"/>
+								<int key="firstAttribute">6</int>
 								<int key="relation">0</int>
-								<reference key="secondItem" ref="354401613"/>
-								<int key="secondAttribute">4</int>
-								<float key="multiplier">1</float>
-								<object class="IBNSLayoutSymbolicConstant" key="constant">
-									<double key="value">8</double>
-								</object>
-								<float key="priority">1000</float>
-								<int key="scoringType">6</int>
-								<float key="scoringTypeFloat">24</float>
-								<int key="contentType">3</int>
-								<reference key="containingView" ref="942749259"/>
-							</object>
-							<object class="IBNSLayoutConstraint" id="585003142">
-								<reference key="firstItem" ref="874635734"/>
-								<int key="firstAttribute">5</int>
-								<int key="relation">0</int>
-								<reference key="secondItem" ref="75290957"/>
+								<reference key="secondItem" ref="874635734"/>
 								<int key="secondAttribute">6</int>
-								<float key="multiplier">1</float>
-								<object class="IBNSLayoutSymbolicConstant" key="constant">
-									<double key="value">12</double>
-								</object>
-								<float key="priority">1000</float>
-								<int key="scoringType">6</int>
-								<float key="scoringTypeFloat">24</float>
-								<int key="contentType">3</int>
-								<reference key="containingView" ref="942749259"/>
-							</object>
-							<object class="IBNSLayoutConstraint" id="419097633">
-								<reference key="firstItem" ref="354401613"/>
-								<int key="firstAttribute">5</int>
-								<int key="relation">0</int>
-								<reference key="secondItem" ref="942749259"/>
-								<int key="secondAttribute">5</int>
 								<float key="multiplier">1</float>
 								<object class="IBNSLayoutSymbolicConstant" key="constant">
 									<double key="value">20</double>
 								</object>
 								<float key="priority">1000</float>
+								<reference key="containingView" ref="942749259"/>
 								<int key="scoringType">8</int>
 								<float key="scoringTypeFloat">29</float>
 								<int key="contentType">3</int>
-								<reference key="containingView" ref="942749259"/>
-							</object>
-							<object class="IBNSLayoutConstraint" id="870788339">
-								<reference key="firstItem" ref="627233489"/>
-								<int key="firstAttribute">3</int>
-								<int key="relation">0</int>
-								<reference key="secondItem" ref="146005933"/>
-								<int key="secondAttribute">4</int>
-								<float key="multiplier">1</float>
-								<object class="IBLayoutConstant" key="constant">
-									<double key="value">5</double>
-								</object>
-								<float key="priority">1000</float>
-								<int key="scoringType">9</int>
-								<float key="scoringTypeFloat">40</float>
-								<int key="contentType">3</int>
-								<reference key="containingView" ref="942749259"/>
-							</object>
-							<object class="IBNSLayoutConstraint" id="446599247">
-								<reference key="firstItem" ref="942749259"/>
-								<int key="firstAttribute">4</int>
-								<int key="relation">0</int>
-								<reference key="secondItem" ref="627233489"/>
-								<int key="secondAttribute">4</int>
-								<float key="multiplier">1</float>
-								<object class="IBLayoutConstant" key="constant">
-									<double key="value">8</double>
-								</object>
-								<float key="priority">1000</float>
-								<int key="scoringType">9</int>
-								<float key="scoringTypeFloat">40</float>
-								<int key="contentType">3</int>
-								<reference key="containingView" ref="942749259"/>
-							</object>
-							<object class="IBNSLayoutConstraint" id="317996171">
-								<reference key="firstItem" ref="354401613"/>
-								<int key="firstAttribute">3</int>
-								<int key="relation">0</int>
-								<reference key="secondItem" ref="942749259"/>
-								<int key="secondAttribute">3</int>
-								<float key="multiplier">1</float>
-								<object class="IBLayoutConstant" key="constant">
-									<double key="value">11</double>
-								</object>
-								<float key="priority">1000</float>
-								<int key="scoringType">9</int>
-								<float key="scoringTypeFloat">40</float>
-								<int key="contentType">3</int>
-								<reference key="containingView" ref="942749259"/>
 							</object>
 							<object class="IBNSLayoutConstraint" id="67492260">
 								<reference key="firstItem" ref="75290957"/>
@@ -567,10 +398,202 @@
 									<double key="value">0.0</double>
 								</object>
 								<float key="priority">1000</float>
+								<reference key="containingView" ref="942749259"/>
 								<int key="scoringType">9</int>
 								<float key="scoringTypeFloat">40</float>
 								<int key="contentType">5</int>
+							</object>
+							<object class="IBNSLayoutConstraint" id="339948509">
+								<reference key="firstItem" ref="942749259"/>
+								<int key="firstAttribute">4</int>
+								<int key="relation">0</int>
+								<reference key="secondItem" ref="75290957"/>
+								<int key="secondAttribute">4</int>
+								<float key="multiplier">1</float>
+								<object class="IBNSLayoutSymbolicConstant" key="constant">
+									<double key="value">20</double>
+								</object>
+								<float key="priority">1000</float>
 								<reference key="containingView" ref="942749259"/>
+								<int key="scoringType">8</int>
+								<float key="scoringTypeFloat">29</float>
+								<int key="contentType">3</int>
+							</object>
+							<object class="IBNSLayoutConstraint" id="626044727">
+								<reference key="firstItem" ref="75290957"/>
+								<int key="firstAttribute">5</int>
+								<int key="relation">0</int>
+								<reference key="secondItem" ref="627233489"/>
+								<int key="secondAttribute">6</int>
+								<float key="multiplier">1</float>
+								<object class="IBNSLayoutSymbolicConstant" key="constant">
+									<double key="value">8</double>
+								</object>
+								<float key="priority">1000</float>
+								<reference key="containingView" ref="942749259"/>
+								<int key="scoringType">6</int>
+								<float key="scoringTypeFloat">24</float>
+								<int key="contentType">3</int>
+							</object>
+							<object class="IBNSLayoutConstraint" id="737220108">
+								<reference key="firstItem" ref="627233489"/>
+								<int key="firstAttribute">3</int>
+								<int key="relation">0</int>
+								<reference key="secondItem" ref="942749259"/>
+								<int key="secondAttribute">3</int>
+								<float key="multiplier">1</float>
+								<object class="IBLayoutConstant" key="constant">
+									<double key="value">275</double>
+								</object>
+								<float key="priority">1000</float>
+								<reference key="containingView" ref="942749259"/>
+								<int key="scoringType">3</int>
+								<float key="scoringTypeFloat">9</float>
+								<int key="contentType">3</int>
+							</object>
+							<object class="IBNSLayoutConstraint" id="306432732">
+								<reference key="firstItem" ref="627233489"/>
+								<int key="firstAttribute">4</int>
+								<int key="relation">0</int>
+								<reference key="secondItem" ref="942749259"/>
+								<int key="secondAttribute">4</int>
+								<float key="multiplier">1</float>
+								<object class="IBLayoutConstant" key="constant">
+									<double key="value">0.0</double>
+								</object>
+								<float key="priority">1000</float>
+								<reference key="containingView" ref="942749259"/>
+								<int key="scoringType">8</int>
+								<float key="scoringTypeFloat">29</float>
+								<int key="contentType">3</int>
+							</object>
+							<object class="IBNSLayoutConstraint" id="387158952">
+								<reference key="firstItem" ref="627233489"/>
+								<int key="firstAttribute">5</int>
+								<int key="relation">0</int>
+								<reference key="secondItem" ref="942749259"/>
+								<int key="secondAttribute">5</int>
+								<float key="multiplier">1</float>
+								<object class="IBNSLayoutSymbolicConstant" key="constant">
+									<double key="value">20</double>
+								</object>
+								<float key="priority">1000</float>
+								<reference key="containingView" ref="942749259"/>
+								<int key="scoringType">8</int>
+								<float key="scoringTypeFloat">29</float>
+								<int key="contentType">3</int>
+							</object>
+							<object class="IBNSLayoutConstraint" id="1028406761">
+								<reference key="firstItem" ref="942749259"/>
+								<int key="firstAttribute">4</int>
+								<int key="relation">0</int>
+								<reference key="secondItem" ref="146005933"/>
+								<int key="secondAttribute">4</int>
+								<float key="multiplier">1</float>
+								<object class="IBLayoutConstant" key="constant">
+									<double key="value">56</double>
+								</object>
+								<float key="priority">1000</float>
+								<reference key="containingView" ref="942749259"/>
+								<int key="scoringType">3</int>
+								<float key="scoringTypeFloat">9</float>
+								<int key="contentType">3</int>
+							</object>
+							<object class="IBNSLayoutConstraint" id="408792166">
+								<reference key="firstItem" ref="146005933"/>
+								<int key="firstAttribute">3</int>
+								<int key="relation">0</int>
+								<reference key="secondItem" ref="354401613"/>
+								<int key="secondAttribute">4</int>
+								<float key="multiplier">1</float>
+								<object class="IBNSLayoutSymbolicConstant" key="constant">
+									<double key="value">8</double>
+								</object>
+								<float key="priority">1000</float>
+								<reference key="containingView" ref="942749259"/>
+								<int key="scoringType">6</int>
+								<float key="scoringTypeFloat">24</float>
+								<int key="contentType">3</int>
+							</object>
+							<object class="IBNSLayoutConstraint" id="606436537">
+								<reference key="firstItem" ref="942749259"/>
+								<int key="firstAttribute">6</int>
+								<int key="relation">0</int>
+								<reference key="secondItem" ref="146005933"/>
+								<int key="secondAttribute">6</int>
+								<float key="multiplier">1</float>
+								<object class="IBNSLayoutSymbolicConstant" key="constant">
+									<double key="value">20</double>
+								</object>
+								<float key="priority">1000</float>
+								<reference key="containingView" ref="942749259"/>
+								<int key="scoringType">8</int>
+								<float key="scoringTypeFloat">29</float>
+								<int key="contentType">3</int>
+							</object>
+							<object class="IBNSLayoutConstraint" id="359000243">
+								<reference key="firstItem" ref="146005933"/>
+								<int key="firstAttribute">5</int>
+								<int key="relation">0</int>
+								<reference key="secondItem" ref="942749259"/>
+								<int key="secondAttribute">5</int>
+								<float key="multiplier">1</float>
+								<object class="IBNSLayoutSymbolicConstant" key="constant">
+									<double key="value">20</double>
+								</object>
+								<float key="priority">1000</float>
+								<reference key="containingView" ref="942749259"/>
+								<int key="scoringType">8</int>
+								<float key="scoringTypeFloat">29</float>
+								<int key="contentType">3</int>
+							</object>
+							<object class="IBNSLayoutConstraint" id="1052164442">
+								<reference key="firstItem" ref="354401613"/>
+								<int key="firstAttribute">3</int>
+								<int key="relation">0</int>
+								<reference key="secondItem" ref="942749259"/>
+								<int key="secondAttribute">3</int>
+								<float key="multiplier">1</float>
+								<object class="IBLayoutConstant" key="constant">
+									<double key="value">11</double>
+								</object>
+								<float key="priority">1000</float>
+								<reference key="containingView" ref="942749259"/>
+								<int key="scoringType">3</int>
+								<float key="scoringTypeFloat">9</float>
+								<int key="contentType">3</int>
+							</object>
+							<object class="IBNSLayoutConstraint" id="419097633">
+								<reference key="firstItem" ref="354401613"/>
+								<int key="firstAttribute">5</int>
+								<int key="relation">0</int>
+								<reference key="secondItem" ref="942749259"/>
+								<int key="secondAttribute">5</int>
+								<float key="multiplier">1</float>
+								<object class="IBNSLayoutSymbolicConstant" key="constant">
+									<double key="value">20</double>
+								</object>
+								<float key="priority">1000</float>
+								<reference key="containingView" ref="942749259"/>
+								<int key="scoringType">8</int>
+								<float key="scoringTypeFloat">29</float>
+								<int key="contentType">3</int>
+							</object>
+							<object class="IBNSLayoutConstraint" id="1042134971">
+								<reference key="firstItem" ref="942749259"/>
+								<int key="firstAttribute">6</int>
+								<int key="relation">0</int>
+								<reference key="secondItem" ref="354401613"/>
+								<int key="secondAttribute">6</int>
+								<float key="multiplier">1</float>
+								<object class="IBNSLayoutSymbolicConstant" key="constant">
+									<double key="value">20</double>
+								</object>
+								<float key="priority">1000</float>
+								<reference key="containingView" ref="942749259"/>
+								<int key="scoringType">8</int>
+								<float key="scoringTypeFloat">29</float>
+								<int key="contentType">3</int>
 							</object>
 						</array>
 						<reference key="parent" ref="11664095"/>
@@ -578,24 +601,7 @@
 					<object class="IBObjectRecord">
 						<int key="objectID">5</int>
 						<reference key="object" ref="627233489"/>
-						<array class="NSMutableArray" key="children">
-							<object class="IBNSLayoutConstraint" id="999582859">
-								<reference key="firstItem" ref="627233489"/>
-								<int key="firstAttribute">8</int>
-								<int key="relation">0</int>
-								<nil key="secondItem"/>
-								<int key="secondAttribute">0</int>
-								<float key="multiplier">1</float>
-								<object class="IBLayoutConstant" key="constant">
-									<double key="value">43</double>
-								</object>
-								<float key="priority">1000</float>
-								<int key="scoringType">9</int>
-								<float key="scoringTypeFloat">40</float>
-								<int key="contentType">1</int>
-								<reference key="containingView" ref="627233489"/>
-							</object>
-						</array>
+						<array class="NSMutableArray" key="children"/>
 						<reference key="parent" ref="942749259"/>
 					</object>
 					<object class="IBObjectRecord">
@@ -614,10 +620,10 @@
 									<double key="value">95</double>
 								</object>
 								<float key="priority">1000</float>
+								<reference key="containingView" ref="75290957"/>
 								<int key="scoringType">3</int>
 								<float key="scoringTypeFloat">9</float>
 								<int key="contentType">1</int>
-								<reference key="containingView" ref="75290957"/>
 							</object>
 						</array>
 						<reference key="parent" ref="942749259"/>
@@ -720,29 +726,29 @@
 						<reference key="parent" ref="942749259"/>
 					</object>
 					<object class="IBObjectRecord">
-						<int key="objectID">38</int>
-						<reference key="object" ref="870788339"/>
-						<reference key="parent" ref="942749259"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">39</int>
-						<reference key="object" ref="446599247"/>
-						<reference key="parent" ref="942749259"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">40</int>
-						<reference key="object" ref="317996171"/>
-						<reference key="parent" ref="942749259"/>
-					</object>
-					<object class="IBObjectRecord">
 						<int key="objectID">41</int>
 						<reference key="object" ref="67492260"/>
 						<reference key="parent" ref="942749259"/>
 					</object>
 					<object class="IBObjectRecord">
-						<int key="objectID">42</int>
-						<reference key="object" ref="999582859"/>
-						<reference key="parent" ref="627233489"/>
+						<int key="objectID">49</int>
+						<reference key="object" ref="1052164442"/>
+						<reference key="parent" ref="942749259"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">50</int>
+						<reference key="object" ref="306432732"/>
+						<reference key="parent" ref="942749259"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">51</int>
+						<reference key="object" ref="1028406761"/>
+						<reference key="parent" ref="942749259"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">52</int>
+						<reference key="object" ref="737220108"/>
+						<reference key="parent" ref="942749259"/>
 					</object>
 				</array>
 			</object>
@@ -768,35 +774,33 @@
 				<string key="34.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="35.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="36.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="38.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="39.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="4.CustomClassName">TESetupAssistantBGView</string>
-				<array key="4.IBNSViewMetadataConstraints">
+				<array class="NSMutableArray" key="4.IBNSViewMetadataConstraints">
+					<reference ref="1042134971"/>
+					<reference ref="419097633"/>
+					<reference ref="1052164442"/>
 					<reference ref="359000243"/>
 					<reference ref="606436537"/>
-					<reference ref="626044727"/>
-					<reference ref="208632930"/>
-					<reference ref="387158952"/>
-					<reference ref="339948509"/>
-					<reference ref="1042134971"/>
-					<reference ref="124283355"/>
 					<reference ref="408792166"/>
-					<reference ref="585003142"/>
-					<reference ref="419097633"/>
-					<reference ref="870788339"/>
-					<reference ref="446599247"/>
-					<reference ref="317996171"/>
+					<reference ref="1028406761"/>
+					<reference ref="387158952"/>
+					<reference ref="306432732"/>
+					<reference ref="737220108"/>
+					<reference ref="626044727"/>
+					<reference ref="339948509"/>
 					<reference ref="67492260"/>
+					<reference ref="208632930"/>
+					<reference ref="124283355"/>
+					<reference ref="585003142"/>
 				</array>
 				<string key="4.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="40.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="41.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="42.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<array class="NSMutableArray" key="5.IBNSViewMetadataConstraints">
-					<reference ref="999582859"/>
-				</array>
+				<string key="49.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<boolean value="NO" key="5.IBNSViewMetadataTranslatesAutoresizingMaskIntoConstraints"/>
 				<string key="5.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="50.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="51.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="52.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<array key="6.IBNSViewMetadataConstraints">
 					<reference ref="143775697"/>
 				</array>
@@ -813,7 +817,7 @@
 			<nil key="activeLocalization"/>
 			<dictionary class="NSMutableDictionary" key="localizations"/>
 			<nil key="sourceID"/>
-			<int key="maxID">48</int>
+			<int key="maxID">52</int>
 		</object>
 		<object class="IBClassDescriber" key="IBDocument.Classes">
 			<array class="NSMutableArray" key="referencedPartialClassDescriptions">
@@ -823,6 +827,24 @@
 					<object class="IBClassDescriptionSource" key="sourceIdentifier">
 						<string key="majorKey">IBProjectSource</string>
 						<string key="minorKey">./Classes/NSLayoutConstraint.h</string>
+					</object>
+				</object>
+				<object class="IBPartialClassDescription">
+					<string key="className">NSWindow</string>
+					<object class="NSMutableDictionary" key="actions">
+						<string key="NS.key.0">stopModalSheet:</string>
+						<string key="NS.object.0">id</string>
+					</object>
+					<object class="NSMutableDictionary" key="actionInfosByName">
+						<string key="NS.key.0">stopModalSheet:</string>
+						<object class="IBActionInfo" key="NS.object.0">
+							<string key="name">stopModalSheet:</string>
+							<string key="candidateClassName">id</string>
+						</object>
+					</object>
+					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+						<string key="majorKey">IBProjectSource</string>
+						<string key="minorKey">./Classes/NSWindow.h</string>
 					</object>
 				</object>
 				<object class="IBPartialClassDescription">

--- a/TESetupAssistant/TESetupAssistant.h
+++ b/TESetupAssistant/TESetupAssistant.h
@@ -108,6 +108,7 @@
 - (NSView *)specialView;
 - (NSBox *)assistantBox;
 - (NSArray *)assistants;
+ACC_RETURN_H(NSMutableDictionary*, sessionDict);
 - (TEBaseAssistant *)prevAssistant;
 - (TEBaseAssistant *)nextAssistant;
 - (TEBaseAssistant *)currAssistant;

--- a/TESetupAssistant/TESetupAssistant.h
+++ b/TESetupAssistant/TESetupAssistant.h
@@ -98,6 +98,8 @@
 - (void)insertNextAssistant:(TEBaseAssistant *)assistant;
 - (void)setObject:(id)obj forKey:(id)key; // these manipulate the sessionDict
 - (id)objectForKey:(id)key;
+- (void)runAssistant:(TEBaseAssistant*)assistant lastStep:(BOOL)lastStep;
+
 
 // Accessors
 - (NSWindow *)window;

--- a/TESetupAssistant/TESetupAssistant.m
+++ b/TESetupAssistant/TESetupAssistant.m
@@ -145,7 +145,6 @@
 	[window close];
 	if ( modal ) [NSApp stopModal];
 	[assistants removeAllObjects];
-	[sessionDict removeAllObjects];
 	[installStepView clearSteps];
 	[assistantBox setContentView:nil];
 }
@@ -268,6 +267,7 @@ ACC_RETURN_M(NSButton *, nextButton)
 ACC_RETURN_M(NSView   *, specialView)
 ACC_RETURN_M(NSBox    *, assistantBox)
 ACC_RETURN_M(NSArray  *, assistants)
+ACC_RETURN_M(NSMutableDictionary *, sessionDict)
 @end
 
 

--- a/TESetupAssistant/TESetupAssistant.m
+++ b/TESetupAssistant/TESetupAssistant.m
@@ -47,7 +47,6 @@
 @end
 
 @interface TESetupAssistant (Private)
-- (void)runAssistant:(TEBaseAssistant*)assistant lastStep:(BOOL)lastStep;
 - (void)insertAssistant:(TEBaseAssistant*)assistant atIndex:(NSUInteger)index;
 @end
 @implementation TESetupAssistant


### PR DESCRIPTION
I want to support skipping of assistants because not all my assistants work linear, also a property is provided for easier access to the complete session dictionary (I use it when I receive the finished notification in my app delegate class). Also resized the special accessory view in the mini version of the TESetupAssistant to window's bottom for easier position calculations (for example to position an extra cancel button in one line with the other default buttons by just copying their y position)
